### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4660,6 +4660,10 @@ d-references {
   <h2>Table of contents</h2>
   <ul>`;
 
+    ToC += "</ul></nav>";
+    element.innerHTML = ToC;
+    const tocList = element.querySelector("ul");
+
     for (const el of headings) {
       // should element be included in TOC?
       const isInTitle = el.parentElement.tagName == "D-TITLE";
@@ -4669,17 +4673,21 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
-      if (el.tagName == "H3") {
-        newLine = "<ul>" + newLine + "</ul>";
-      } else {
-        newLine += "<br>";
-      }
-      ToC += newLine;
-    }
+      const li = document.createElement("li");
+      const a = document.createElement("a");
+      a.setAttribute("href", link);
+      a.textContent = title;
+      li.appendChild(a);
 
-    ToC += "</ul></nav>";
-    element.innerHTML = ToC;
+      if (el.tagName == "H3") {
+        const nested = document.createElement("ul");
+        nested.appendChild(li);
+        tocList.appendChild(nested);
+      } else {
+        tocList.appendChild(li);
+        tocList.appendChild(document.createElement("br"));
+      }
+    }
   }
 
   // Copyright 2018 The Distill Template Authors


### PR DESCRIPTION
Potential fix for [https://github.com/5ayam5/5ayam5.github.io/security/code-scanning/8](https://github.com/5ayam5/5ayam5.github.io/security/code-scanning/8)

General fix: never concatenate DOM-derived text into HTML strings that are later assigned with `innerHTML`. Instead, build DOM nodes (`createElement`), set text via `textContent`, set URL fragments via safe attributes/properties, and append nodes directly.

Best fix here (without changing functionality): keep the existing static wrapper HTML/CSS string if needed, but remove tainted text from string concatenation by constructing the list entries as DOM elements and appending them into the `<ul>` after `innerHTML` initializes the container. Specifically in `assets/js/distillpub/template.v2.js`, replace the loop that builds `newLine`/`ToC += newLine`, remove `ToC += "</ul></nav>";`, and replace `element.innerHTML = ToC;` with:
1. `element.innerHTML = ToC + "</ul></nav>";`
2. `const tocList = element.querySelector("ul");`
3. create `<li>`, `<a>`, and optional nested `<ul>` / `<br>` nodes using DOM APIs.
4. assign `a.textContent = title` (safe text insertion), `a.setAttribute("href", link)`, and append.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
