### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3330,7 +3330,7 @@ d-citation-list .references .title {
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {
         pattern:
-          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[\s\S]*?\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
         lookbehind: true,
         greedy: true,
       },


### PR DESCRIPTION
Potential fix for [https://github.com/5ayam5/5ayam5.github.io/security/code-scanning/4](https://github.com/5ayam5/5ayam5.github.io/security/code-scanning/4)

To fix this without changing functionality, replace the `[\s\S]*?` inside the block-comment part of the lookahead with a linear-time, non-ambiguous block-comment pattern that does not rely on “match anything lazily then backtrack to `*/`”.

Best replacement pattern for comment bodies:

- From: `\/\*[\s\S]*?\*\/`
- To: `\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/`

This classic form matches C-style block comments without catastrophic backtracking by consuming runs of non-`*` and controlled `*` groups until the closing `/`. It preserves intended behavior (matching `/* ... */` in the lookahead) while removing the problematic ambiguous wildcard repetition.

Edit only `assets/js/distillpub/template.v2.js` at the regex on line 3333.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
